### PR TITLE
Wip join tables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+npm-debug.log

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 npm-debug.log
+helper.js

--- a/db/migrations/20180103061348_initial.js
+++ b/db/migrations/20180103061348_initial.js
@@ -1,0 +1,97 @@
+
+exports.up = function(knex, Promise) {
+  return Promise.all([
+    knex.schema.createTable('users', (table) => {
+      table.increments('id').primary();
+      table.string('user_name');
+      table.string('user_image');
+      table.string('user_about');
+      table.string('user_location');
+      table.string('user_email');
+      table.timestamps(true, true);
+    }),
+
+    knex.schema.createTable('professionals', (table) => {
+      table.increments('id').primary();
+      table.string('professional_name');
+      table.string('professional_image');
+      table.string('professional_location');
+      table.string('professional_email');
+      table.string('professional_phone');
+      table.timestamps(true, true);
+    }),
+
+    knex.schema.createTable('challenges', (table) => {
+      table.increments('id').primary();
+      table.string('challenge_name');
+      table.timestamps(true, true);
+    }),
+
+    knex.schema.createTable('insurance_providers', (table) => {
+      table.increments('id').primary();
+      table.string('insurance_provider_name');
+      table.timestamps(true, true);
+    }),
+
+    knex.schema.createTable('specialties', (table) => {
+      table.increments('id').primary();
+      table.string('specialty_name');
+      table.timestamps(true, true);
+    }),
+
+    knex.schema.createTable('favorite_users', (table) => {
+      table.integer('user_id').unsigned();
+      table.foreign('user_id').references('users.id');
+      table.integer('favorite_user_id').unsigned();
+      table.foreign('favorite_user_id').references('users.id');
+      table.timestamps(true, true);
+    }),
+
+    knex.schema.createTable('favorite_professionals', (table) => {
+      table.integer('user_id').unsigned();
+      table.foreign('user_id').references('users.id');
+      table.integer('favorite_professional_id').unsigned();
+      table.foreign('favorite_professional_id').references('professionals.id');
+      table.timestamps(true, true);
+    }),
+
+    knex.schema.createTable('professional_specialties', (table) => {
+      table.integer('professional_id').unsigned();
+      table.foreign('professional_id').references('professionals.id');
+      table.integer('specialty_id').unsigned();
+      table.foreign('specialty_id').references('specialties.id');
+      table.timestamps(true, true);
+    }),
+
+    knex.schema.createTable('professional_insurance_providers', (table) => {
+      table.integer('professional_id').unsigned();
+      table.foreign('professional_id').references('professionals.id');
+      table.integer('insurance_provider_id').unsigned();
+      table.foreign('insurance_provider_id').references('insurance_providers.id');
+      table.timestamps(true, true);
+    }),
+
+    knex.schema.createTable('user_challenges', (table) => {
+      table.integer('user_id').unsigned();
+      table.foreign('user_id').references('users.id');
+      table.integer('challenge_id').unsigned();
+      table.foreign('challenge_id').references('challenges.id');
+      table.timestamps(true, true);
+    })
+  ]);
+};
+
+exports.down = function(knex, Promise) {
+  return Promise.all([
+    knex.schema.dropTable('user_challenges'),
+    knex.schema.dropTable('professional_insurance_providers'),
+    knex.schema.dropTable('professional_specialties'),
+    knex.schema.dropTable('favorite_professionals'),
+    knex.schema.dropTable('favorite_users'),
+    knex.schema.dropTable('specialties'),
+    knex.schema.dropTable('insurance_providers'),
+    knex.schema.dropTable('challenges'),
+    knex.schema.dropTable('professionals'),
+    knex.schema.dropTable('users')
+  ]);
+};

--- a/db/seeds/dev/mental_health_app.js
+++ b/db/seeds/dev/mental_health_app.js
@@ -1,0 +1,182 @@
+const userData = [{
+  id: 1,
+  user_name: 'Jen',
+  user_about: 'blah',
+  user_location: 'Denver',
+  user_email: 'jen@email.com'
+},
+{
+  id: 2,
+  user_name: 'Lola',
+  user_about: 'blah blah',
+  user_location: 'Denver',
+  user_email: 'lola@email.com'
+},
+{
+  id: 3,
+  user_name: 'Cameron',
+  user_about: 'blah blah blah',
+  user_location: 'Denver',
+  user_email: 'cam@email.com'
+}
+];
+
+const profData = [{
+  id: 1,
+  professional_name: 'Dr. Psych',
+  professional_location: 'Denver',
+  professional_email: 'psych@email.com',
+  professional_phone: '555-555-5555'
+},
+{
+  id: 2,
+  professional_name: 'Dr. Healthy',
+  professional_location: 'Denver',
+  professional_email: 'health@email.com',
+  professional_phone: '555-555-1234'
+},
+{
+  id: 3,
+  professional_name: 'Dr. Mind',
+  professional_location: 'Denver',
+  professional_email: 'mind@email.com',
+  professional_phone: '555-555-1111'
+}];
+
+const challengeData = [{
+  id: 1,
+  challenge_name: 'Depression'
+},
+{ id: 2,
+  challenge_name: 'Anxiety'
+},
+{
+  id: 3,
+  challenge_name: 'OCD'
+}];
+
+const insuranceData = [{
+  id: 1,
+  insurance_provider_name: 'Blue Cross'
+},
+{
+  id: 2,
+  insurance_provider_name: 'Aetna'
+},
+{
+  id: 3,
+  insurance_provider_name: 'Cygna'
+}];
+
+const specialtyData = [{
+  id: 1,
+  specialty_name: 'Couples'
+},
+{ id: 2,
+  specialty_name: 'LGBTQ'
+},
+{ id: 3,
+  specialty_name: 'Non-religious'
+}];
+
+
+exports.seed = function(knex, Promise) {
+  // Deletes ALL existing entries
+  return knex('user_challenges').del()
+    .then(() => knex('professional_insurance_providers').del())
+    .then(() => knex('professional_specialties').del())
+    .then(() => knex('favorite_professionals').del())
+    .then(() => knex('favorite_users').del())
+    .then(() => knex('specialties').del())
+    .then(() => knex('insurance_providers').del())
+    .then(() => knex('challenges').del())
+    .then(() => knex('professionals').del())
+    .then(() => knex('users').del())
+    .then(() => {
+      return knex('users').insert(userData);
+    })
+    .then(() => {
+      return knex('professionals').insert(profData);
+    })
+    .then(() => {
+      return knex('challenges').insert(challengeData);
+    })
+    .then(() => {
+      return knex('insurance_providers').insert(insuranceData);
+    })
+    .then(() => {
+      return knex('specialties').insert(specialtyData);
+    })
+    .then(() => {
+      return knex('favorite_users').insert({
+        user_id: 1,
+        favorite_user_id: 2
+      },
+      {
+        user_id: 1,
+        favorite_user_id: 3
+      },
+      {
+        user_id: 2,
+        favorite_user_id: 3
+      });
+    })
+    .then(() => {
+      return knex('favorite_professionals').insert({
+        user_id: 1,
+        favorite_professional_id: 1
+      },
+      {
+        user_id: 1,
+        favorite_user_id: 3
+      },
+      {
+        user_id: 2,
+        favorite_user_id: 3
+      });
+    })
+    .then(() => {
+      return knex('professional_specialties').insert({
+        professional_id: 1,
+        specialty_id: 1
+      },
+      {
+        professional_id: 2,
+        specialty_id: 3
+      },
+      {
+        professional_id: 3,
+        specialty_id: 2
+      });
+    })
+    .then(() => {
+      return knex('professional_insurance_providers').insert({
+        professional_id: 1,
+        insurance_provider_id: 1
+      },
+      {
+        professional_id: 2,
+        insurance_provider_id: 3
+      },
+      {
+        professional_id: 3,
+        insurance_provider_id: 2
+      });
+    })
+    .then(() => {
+      return knex('user_challenges').insert({
+        user_id: 1,
+        challenge_id: 1
+      },
+      {
+        user_id: 2,
+        challenge_id: 3
+      },
+      {
+        user_id: 3,
+        challenge_id: 2
+      });
+    })
+    .then(() => console.log('Seeding complete'))
+    .catch(error => console.log(`Error seeding data: ${error}`));
+};

--- a/db/seeds/dev/mental_health_app.js
+++ b/db/seeds/dev/mental_health_app.js
@@ -175,6 +175,10 @@ exports.seed = function(knex, Promise) {
       {
         user_id: 1,
         challenge_id: 2
+      },
+      {
+        user_id: 3,
+        challenge_id: 2
       });
     })
     .then(() => console.log('Seeding complete'))

--- a/db/seeds/dev/mental_health_app.js
+++ b/db/seeds/dev/mental_health_app.js
@@ -166,14 +166,14 @@ exports.seed = function(knex, Promise) {
     .then(() => {
       return knex('user_challenges').insert({
         user_id: 1,
-        challenge_id: 1
-      },
-      {
-        user_id: 2,
         challenge_id: 3
       },
       {
-        user_id: 3,
+        user_id: 2,
+        challenge_id: 1
+      },
+      {
+        user_id: 1,
         challenge_id: 2
       });
     })

--- a/knexfile.js
+++ b/knexfile.js
@@ -5,6 +5,9 @@ module.exports = {
     migrations: {
       directory: './db/migrations'
     },
+    seeds: {
+      directory: './db/seeds/dev'
+    },
     useNullAsDefault: true
   }
 };

--- a/knexfile.js
+++ b/knexfile.js
@@ -1,0 +1,10 @@
+module.exports = {
+  development: {
+    client: 'pg',
+    connection: 'postgres://localhost/mental_health_app',
+    migrations: {
+      directory: './db/migrations'
+    },
+    useNullAsDefault: true
+  }
+};

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "NODE_ENV=test ./node_modules/.bin/mocha --exit",
-    "lint": "./node_modules/.bin/eslint ./."
+    "lint": "./node_modules/.bin/eslint ./.",
+    "start": "nodemon server.js"
   },
   "keywords": [],
   "author": "",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "body-parser": "^1.18.2",
     "dotenv": "^4.0.0",
     "express": "^4.16.2",
+    "express-async-await": "^1.1.0",
     "knex": "^0.14.2",
     "pg": "^7.4.0"
   },

--- a/server.js
+++ b/server.js
@@ -111,7 +111,55 @@ app.get('/api/v1/users/:userID', (request, response) => {
     })
     .catch(error => response.status(500).json({ error }));
 });
+
+app.delete('api/v1/users/:userID', (request, response) => {
+  const userID = request.params.userID;
+
+  database('users').where('id', userID).del()
+    .then(() => response.status(204).json( { userID }))
+    .catch(() => response.status(404).json({ error: `Could not find user with id '${userID}'` }));
+});
 // end /users/:userID
+
+// begin /professionals/:professionalID
+app.delete('api/v1/professionals/:professionalID', (request, response) => {
+  const professionalID = request.params.professionalID;
+
+  database('professionals').where('id', professionalID).del()
+    .then(() => response.status(204).json( { professionalID }))
+    .catch(() => response.status(404).json({ error: `Could not find professional with id '${professionalID}'` }));
+});
+// end /professionals/:professionalID
+
+// begin /insuranceProviders/:insuranceProviderID
+app.delete('api/v1/insuranceProviders/:insuranceProviderID', (request, response) => {
+  const insuranceProviderID = request.params.insuranceProviderID;
+
+  database('insuranceProviders').where('id', insuranceProviderID).del()
+    .then(() => response.status(204).json( { insuranceProviderID }))
+    .catch(() => response.status(404).json({ error: `Could not find insurance provider with id '${insuranceProviderID}'` }));
+});
+// end /insuranceProviders/:insuranceProviderID
+
+// begin /specialties/:specialtyID
+app.delete('api/v1/specialties/:specialtyID', (request, response) => {
+  const specialtyID = request.params.specialtyID;
+
+  database('specialties').where('id', specialtyID).del()
+    .then(() => response.status(204).json( { specialtyID }))
+    .catch(() => response.status(404).json({ error: `Could not find specialty with id '${specialtyID}'` }));
+});
+// end /specialties/:specialtyID
+
+// begin /challenges/:challengeID
+app.delete('api/v1/challenges/:challengeID', (request, response) => {
+  const challengeID = request.params.challengeID;
+
+  database('challenges').where('id', challengeID).del()
+    .then(() => response.status(204).json( { challengeID }))
+    .catch(() => response.status(404).json({ error: `Could not find challenge with id '${challengeID}'` }));
+});
+// end /challenges/:challengeID
 
 // begin /favoriteUsers/:userID
 app.get('/api/v1/favoriteUsers/:userID', (request, response) => {
@@ -126,6 +174,20 @@ app.get('/api/v1/favoriteUsers/:userID', (request, response) => {
 });
 // end /favoriteUsers/:userID
 
+// begin /favoriteUsers/:userID/:favoriteUserID
+app.delete('/api/v1/favoriteUsers/:userID/:favoriteUserID', (request, response) => {
+  const userID = request.params.userID;
+  const favoriteUserID = request.params.favoriteUserID;
+
+  database('favorite_users').where({
+    user_id: userID,
+    favorite_user_id: favoriteUserID
+  }).del()
+    .then(() => response.status(204).json( { favoriteUserID }))
+    .catch(() => response.status(404).json({ error: `Could not find favorite user with id '${favoriteUserID}' for user id ${userID}` }));
+});
+// end /favoriteUsers/:userID/:favoriteUserID
+
 // begin /favoriteProfessionals/:userID
 app.get('/api/v1/favoriteProfessionals/:userID', (request, response) => {
   database('favorite_professionals').where('user_id', request.params.userID).select()
@@ -138,6 +200,20 @@ app.get('/api/v1/favoriteProfessionals/:userID', (request, response) => {
     .catch(error => response.status(500).json({ error }));
 });
 // end /favoriteProfessionals/:userID
+
+// begin /favoriteProfessionals/:userID/:favoriteProfessionalID
+app.delete('/api/v1/favoriteProfessionals/:userID/:favoriteProfessionalID', (request, response) => {
+  const userID = request.params.userID;
+  const favoriteProfessionalID = request.params.favoriteProfessionalID;
+
+  database('favorite_professionals').where({
+    user_id: userID,
+    favorite_professional_id: favoriteProfessionalID
+  }).del()
+    .then(() => response.status(204).json( { favoriteProfessionalID }))
+    .catch(() => response.status(404).json({ error: `Could not find favorite professional with id '${favoriteProfessionalID}' for user id ${userID}` }));
+});
+// end /favoriteProfessionals/:userID/:favoriteProfessionalID
 
 app.listen(app.get('port'), () => {
   // eslint-disable-next-line

--- a/server.js
+++ b/server.js
@@ -39,9 +39,12 @@ app.get('/api/v1/users', (request, response) => {
   const queryParameterValue = request.query[queryParameter];
 
   if (!queryParameter) {
+    // returns one item for each entry in user_challenges instead of one item per user in users,
+    // each with an array of challenges
     database('users')
-      // .join('user_challenges', 'user_challenges.user_id', '=', 'users.id')
-      .select()
+      .join('user_challenges', 'users.id', '=', 'user_challenges.user_id')
+      .join('challenges', 'challenges.id', 'user_challenges.challenge_id')
+      .select('users.*', 'challenges.challenge_name')
       .then(users => response.status(200).json({ users }))
       .catch(error => response.status(500).json({ error }));
   } else {
@@ -264,10 +267,13 @@ app.post('/api/v1/challenges', (request, response) => {
 
 // begin /users/:userID
 app.get('/api/v1/users/:userID', (request, response) => {
+  // will return 404 if user id does not exist in user_challenges
+  // only returns 1st challenge, not all challenges
   database('users')
-    .join('user_challenges', 'users.id', 'user_challenges.user_id')
     .where('users.id', request.params.userID)
-    .select()
+    .join('user_challenges', 'users.id', '=', 'user_challenges.user_id')
+    .join('challenges', 'challenges.id', '=', 'user_challenges.challenge_id')
+    .select('users.*', 'challenges.challenge_name')
     .then(user => {
       if (user.length) {
         return response.status(200).json({ user: user[0] });

--- a/server.js
+++ b/server.js
@@ -34,17 +34,45 @@ app.get('/', (request, response) => {
 
 // begin /users
 app.get('/api/v1/users', (request, response) => {
-  database('users').select()
-    .then(users => response.status(200).json({ users }))
-    .catch(error => response.status(500).json({ error }));
+  const queryParameter = Object.keys(request.query)[0];
+  const queryParameterValue = request.query[queryParameter];
+
+  if (!queryParameter) {
+    database('users').select()
+      .then(users => response.status(200).json({ users }))
+      .catch(error => response.status(500).json({ error }));
+  } else {
+    database('users').where(queryParameter.toLowerCase(), queryParameterValue.toLowerCase()).select()
+      .then(users => {
+        if (!users.length) {
+          return response.status(404).json({ error: `Could not find any users associated with '${queryParameter}' of '${queryParameterValue}'` });
+        }
+        return response.status(200).json({ users });
+      })
+      .catch(error => response.status(500).json({ error }));
+  }
 });
 // end /users
 
 // begin /professionals
 app.get('/api/v1/professionals', (request, response) => {
-  database('professionals').select()
-    .then(professionals => response.status(200).json({ professionals }))
-    .catch(error => response.status(500).json({ error }));
+  const queryParameter = Object.keys(request.query)[0];
+  const queryParameterValue = request.query[queryParameter];
+
+  if (!queryParameter) {
+    database('professionals').select()
+      .then(professionals => response.status(200).json({ professionals }))
+      .catch(error => response.status(500).json({ error }));
+  } else {
+    database('professionals').where(queryParameter.toLowerCase(), queryParameterValue.toLowerCase()).select()
+      .then(professionals => {
+        if (!professionals.length) {
+          return response.status(404).json({ error: `Could not find any professionals associated with '${queryParameter}' of '${queryParameterValue}'` });
+        }
+        return response.status(200).json({ professionals });
+      })
+      .catch(error => response.status(500).json({ error }));
+  }
 });
 // end /professionals
 

--- a/server.js
+++ b/server.js
@@ -39,23 +39,14 @@ app.get('/api/v1/users', (request, response) => {
   const queryParameterValue = request.query[queryParameter];
 
   if (!queryParameter) {
-    // returns one item for each entry in user_challenges instead of one item per user in users,
-    // each with an array of challenges
     database('users')
-      // .join('user_challenges', 'users.id', '=', 'user_challenges.user_id')
-      // .join('challenges', 'challenges.id', 'user_challenges.challenge_id')
-      // .select('users.*', 'challenges.challenge_name')
-      // .then(users => response.status(200).json({ users }))
       .leftJoin('user_challenges', 'users.id', '=', 'user_challenges.user_id')
       .leftJoin('challenges', 'challenges.id', '=', 'user_challenges.challenge_id')
       .select('users.*', 'challenges.challenge_name')
       .then(users => {
-        // console.log('users: ', users);
         if (users.length) {
-          // let completeUser = {user_challenges: []};
           let allCompleteUsers =[];
           users.forEach(user => {
-
             const completeUserIndex = allCompleteUsers.findIndex(completeUser => {
               return completeUser.id === user.id;
             });

--- a/server.js
+++ b/server.js
@@ -1,0 +1,117 @@
+const express = require('express');
+// will this be necessary? see app.use(express.static)
+// const path = require('path');
+
+const app = express();
+const bodyParser = require('body-parser');
+
+// set up for future use
+// const jwt = require('jsonwebtoken');
+// require('dotenv').config();
+
+app.set('port', process.env.PORT || 3000);
+
+// set up for future use
+// app.set('secretKey', process.env.SECRET_KEY);
+
+// change title when we've decided on application name
+app.locals.title = 'Capstone';
+
+app.use(bodyParser.json());
+app.use(bodyParser.urlencoded({ extended: true }));
+
+const environment = process.env.NODE_ENV || 'development';
+const configuration = require('./knexfile')[environment];
+const database = require('knex')(configuration);
+
+// this would usually serve HTML from the public folder
+// how do we change it to serve files from our other repo?
+// app.use(express.static(path.join(__dirname, '/public')));
+
+app.get('/', (request, response) => {
+  response.send(`It's the backend!`);
+});
+
+// begin /users
+app.get('/api/v1/users', (request, response) => {
+  database('users').select()
+    .then(users => response.status(200).json({ users }))
+    .catch(error => response.status(500).json({ error }));
+});
+// end /users
+
+// begin /professionals
+app.get('/api/v1/professionals', (request, response) => {
+  database('professionals').select()
+    .then(professionals => response.status(200).json({ professionals }))
+    .catch(error => response.status(500).json({ error }));
+});
+// end /professionals
+
+// begin /insuranceProviders
+app.get('/api/v1/insuranceProviders', (request, response) => {
+  database('insuranceProviders').select()
+    .then(insuranceProviders => response.status(200).json({ insuranceProviders }))
+    .catch(error => response.status(500).json({ error }));
+});
+// end /insuranceProviders
+
+// begin /specialties
+app.get('/api/v1/specialties', (request, response) => {
+  database('specialties').select()
+    .then(specialties => response.status(200).json({ specialties }))
+    .catch(error => response.status(500).json({ error }));
+});
+// end /specialties
+
+// begin /challenges
+app.get('/api/v1/challenges', (request, response) => {
+  database('challenges').select()
+    .then(challenges => response.status(200).json({ challenges }))
+    .catch(error => response.status(500).json({ error }));
+});
+// end /challenges
+
+// begin /users/:userID
+app.get('/api/v1/users/:userID', (request, response) => {
+  database('users').where('id', request.params.userID).select()
+    .then(user => {
+      if (user.length) {
+        return response.status(200).json({ user: user[0] });
+      }
+      return response.status(404).json({ error: `Could not find any user associated with id ${request.params.userID}.`});
+    })
+    .catch(error => response.status(500).json({ error }));
+});
+// end /users/:userID
+
+// begin /favoriteUsers/:userID
+app.get('/api/v1/favoriteUsers/:userID', (request, response) => {
+  database('favorite_users').where('user_id', request.params.userID).select()
+    .then(favoriteUsers => {
+      if (favoriteUsers.length) {
+        return response.status(200).json({ favoriteUsers: favoriteUsers[0] });
+      }
+      return response.status(404).json({ error: `Could not find any favorite users for user id ${request.params.userID}.`});
+    })
+    .catch(error => response.status(500).json({ error }));
+});
+// end /favoriteUsers/:userID
+
+// begin /favoriteProfessionals/:userID
+app.get('/api/v1/favoriteProfessionals/:userID', (request, response) => {
+  database('favorite_professionals').where('user_id', request.params.userID).select()
+    .then(favoriteProfessionals => {
+      if (favoriteProfessionals.length) {
+        return response.status(200).json({ favoriteUsers: favoriteProfessionals[0] });
+      }
+      return response.status(404).json({ error: `Could not find any favorite professionals for user id ${request.params.userID}.`});
+    })
+    .catch(error => response.status(500).json({ error }));
+});
+// end /favoriteProfessionals/:userID
+
+app.listen(app.get('port'), () => {
+  // eslint-disable-next-line
+  console.log(`${app.locals.title} is running on ${app.get('port')}`);
+});


### PR DESCRIPTION
This PR gets some endpoints working for real. 
You should be able to use any endpoints that only deal with one table (like GET /challenges) and also:
GET /users
GET /users/:userID
POST /users
GET /professionals

Query for users and professionals does not have the join table hooked up just yet. Other properties should work though, like location, and I'm still working on other endpoints that use join tables.

My experience: 
![](https://media.giphy.com/media/xT4uQlYKYFqhB93EWY/giphy.gif)
